### PR TITLE
salzburg: remove nvidia-persistenced

### DIFF
--- a/sys/salzburg/configuration.nix
+++ b/sys/salzburg/configuration.nix
@@ -27,7 +27,6 @@
 
   services.xserver.enable = true;
   services.xserver.videoDrivers = [ "nvidia" ];
-  hardware.nvidia.nvidiaPersistenced = true;
 
   system.stateVersion = "20.09";
 }


### PR DESCRIPTION
nvidia-persistenced is currently broken and doesn't build.

This is subpar, but it appears hardware acceleration still works despite
the box being headless, even after a reboot, so the GPU remains active
regardless.

```
builder for '/nix/store/b3nqq2njbqnsrkrxm6k9dk6yj8cfwvi2-nvidia-persistenced-455.28.drv' failed with exit code 2; last 10 log lines:
  /nix/store/a2n8nrsf215x01a7fv8l94crdjwf69pa-glibc-2.32-dev/include/features.h:187:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
    187 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
        |   ^~~~~~~
  In file included from nvidia-persistenced.h:33,
                   from command_server.c:32:
  nvpd_rpc.h:9:10: fatal error: rpc/rpc.h: No such file or directory
      9 | #include <rpc/rpc.h>
        |          ^~~~~~~~~~~
  compilation terminated.
  make: *** [Makefile:138: _out/Linux_x86_64/command_server.o] Error 1
```